### PR TITLE
fix(output): Re-work API to work with rustfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,20 @@ fn main() {
     assert_cli::Assert::command(&["ls", "foo-bar-foo"])
         .fails()
         .and()
-        .stderr().contains("foo-bar-foo")
+        .stderr(assert_cli::Output::contains("foo-bar-foo"))
         .unwrap();
 }
 ```
 
 If you want to match the program's output _exactly_, you can use
-`stdout().is` (and shows the macro form of `command`):
+`Output::is` (and shows the macro form of `command`):
 
 ```rust,should_panic
 #[macro_use] extern crate assert_cli;
 
 fn main() {
     assert_cmd!(wc "README.md")
-        .stdout().is("1337 README.md")
+        .stdout(assert_cli::Output::is("1337 README.md"))
         .unwrap();
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! ```rust
 //! assert_cli::Assert::command(&["echo", "42"])
-//!     .stdout().contains("42")
+//!     .stdout(assert_cli::Output::contains("42"))
 //!     .unwrap();
 //! ```
 //!
@@ -26,7 +26,7 @@
 //!
 //! ```rust,should_panic
 //! assert_cli::Assert::command(&["echo", "42"])
-//!     .stdout().is("1337")
+//!     .stdout(assert_cli::Output::is("1337"))
 //!     .unwrap();
 //! ```
 //!
@@ -45,7 +45,7 @@
 //! ```rust
 //! # #[macro_use] extern crate assert_cli;
 //! # fn main() {
-//! assert_cmd!(echo "42").stdout().contains("42").unwrap();
+//! assert_cmd!(echo "42").stdout(assert_cli::Output::contains("42")).unwrap();
 //! # }
 //! ```
 //!
@@ -88,9 +88,9 @@
 //! # #[macro_use] extern crate assert_cli;
 //! # fn main() {
 //! assert_cmd!(echo "Hello world! The ansswer is 42.")
-//!     .stdout().contains("Hello world")
-//!     .stdout().contains("42")
-//!     .stderr().is("")
+//!     .stdout(assert_cli::Output::contains("Hello world"))
+//!     .stdout(assert_cli::Output::contains("42"))
+//!     .stderr(assert_cli::Output::is(""))
 //!     .unwrap();
 //! # }
 //! ```
@@ -110,7 +110,7 @@
 //! ```rust
 //! # #[macro_use] extern crate assert_cli;
 //! # fn main() {
-//! let x = assert_cmd!(echo "1337").stdout().is("42").execute();
+//! let x = assert_cmd!(echo "1337").stdout(assert_cli::Output::is("42")).execute();
 //! assert!(x.is_err());
 //! # }
 //! ```
@@ -130,13 +130,12 @@ mod macros;
 pub use macros::flatten_escaped_string;
 
 mod output;
-
 mod diff;
-
 mod assert;
+
 pub use assert::Assert;
-pub use assert::OutputAssertionBuilder;
 /// Environment is a re-export of the Environment crate
 ///
 /// It allow you to define/override environment variables for one or more assertions.
 pub use environment::Environment;
+pub use output::Output;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,7 +22,7 @@ use std::borrow::Cow;
 /// # fn main() {
 /// assert_cmd!(echo "Launch sequence initiated.\nNo errors whatsoever!\n")
 ///     .succeeds()
-///     .stdout().contains("No errors whatsoever")
+///     .stdout(assert_cli::Output::contains("No errors whatsoever"))
 ///     .unwrap();
 /// # }
 /// ```

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,35 +2,17 @@ use self::errors::*;
 pub use self::errors::{Error, ErrorKind};
 use diff;
 use difference::Changeset;
-use std::ffi::OsString;
-use std::process::Output;
+use std::process;
 
-#[derive(Debug, Clone)]
-pub struct OutputAssertion {
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IsPredicate {
     pub expect: String,
-    pub fuzzy: bool,
     pub expected_result: bool,
-    pub kind: OutputKind,
 }
 
-impl OutputAssertion {
-    fn matches_fuzzy(&self, got: &str) -> Result<()> {
-        let result = got.contains(&self.expect);
-        if result != self.expected_result {
-            if self.expected_result {
-                bail!(ErrorKind::OutputDoesntContain(
-                    self.expect.clone(),
-                    got.into()
-                ));
-            } else {
-                bail!(ErrorKind::OutputContains(self.expect.clone(), got.into()));
-            }
-        }
-
-        Ok(())
-    }
-
-    fn matches_exact(&self, got: &str) -> Result<()> {
+impl IsPredicate {
+    pub fn verify_str(&self, got: &str) -> Result<()> {
         let differences = Changeset::new(self.expect.trim(), got.trim(), "\n");
         let result = differences.distance == 0;
 
@@ -49,20 +31,140 @@ impl OutputAssertion {
 
         Ok(())
     }
+}
 
-    pub fn execute(&self, output: &Output, cmd: &[OsString]) -> super::errors::Result<()> {
-        let observed = String::from_utf8_lossy(self.kind.select(output));
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ContainsPredicate {
+    pub expect: String,
+    pub expected_result: bool,
+}
 
-        let result = if self.fuzzy {
-            self.matches_fuzzy(&observed)
-        } else {
-            self.matches_exact(&observed)
-        };
-        result.map_err(|e| {
-            super::errors::ErrorKind::OutputMismatch(cmd.to_vec(), e, self.kind)
-        })?;
+impl ContainsPredicate {
+    pub fn verify_str(&self, got: &str) -> Result<()> {
+        let result = got.contains(&self.expect);
+        if result != self.expected_result {
+            if self.expected_result {
+                bail!(ErrorKind::OutputDoesntContain(
+                    self.expect.clone(),
+                    got.into()
+                ));
+            } else {
+                bail!(ErrorKind::OutputContains(self.expect.clone(), got.into()));
+            }
+        }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+enum StrPredicate {
+    Is(IsPredicate),
+    Contains(ContainsPredicate),
+}
+
+impl StrPredicate {
+    pub fn verify_str(&self, got: &str) -> Result<()> {
+        match *self {
+            StrPredicate::Is(ref pred) => pred.verify_str(got),
+            StrPredicate::Contains(ref pred) => pred.verify_str(got),
+        }
+    }
+}
+
+/// Assertions for command output.
+#[derive(Debug, Clone)]
+pub struct Output {
+    pred: StrPredicate,
+}
+
+impl Output {
+    /// Expect the command's output to **contain** `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout(assert_cli::Output::contains("42"))
+    ///     .unwrap();
+    /// ```
+    pub fn contains<O: Into<String>>(output: O) -> Self {
+        let pred = ContainsPredicate {
+            expect: output.into(),
+            expected_result: true,
+        };
+        Self::new(StrPredicate::Contains(pred))
+    }
+
+    /// Expect the command to output **exactly** this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout(assert_cli::Output::is("42"))
+    ///     .unwrap();
+    /// ```
+    pub fn is<O: Into<String>>(output: O) -> Self {
+        let pred = IsPredicate {
+            expect: output.into(),
+            expected_result: true,
+        };
+        Self::new(StrPredicate::Is(pred))
+    }
+
+    /// Expect the command's output to not **contain** `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout(assert_cli::Output::doesnt_contain("73"))
+    ///     .unwrap();
+    /// ```
+    pub fn doesnt_contain<O: Into<String>>(output: O) -> Self {
+        let pred = ContainsPredicate {
+            expect: output.into(),
+            expected_result: false,
+        };
+        Self::new(StrPredicate::Contains(pred))
+    }
+
+    /// Expect the command to output to not be **exactly** this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout(assert_cli::Output::isnt("73"))
+    ///     .unwrap();
+    /// ```
+    pub fn isnt<O: Into<String>>(output: O) -> Self {
+        let pred = IsPredicate {
+            expect: output.into(),
+            expected_result: false,
+        };
+        Self::new(StrPredicate::Is(pred))
+    }
+
+    fn new(pred: StrPredicate) -> Self {
+        Self { pred }
+    }
+
+    pub(crate) fn verify_str(&self, got: &str) -> Result<()> {
+        self.pred.verify_str(got)
     }
 }
 
@@ -73,11 +175,45 @@ pub enum OutputKind {
 }
 
 impl OutputKind {
-    pub fn select(self, o: &Output) -> &[u8] {
+    pub fn select(self, o: &process::Output) -> &[u8] {
         match self {
             OutputKind::StdOut => &o.stdout,
             OutputKind::StdErr => &o.stderr,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OutputPredicate {
+    kind: OutputKind,
+    pred: Output,
+}
+
+impl OutputPredicate {
+    pub fn stdout(pred: Output) -> Self {
+        Self {
+            kind: OutputKind::StdOut,
+            pred: pred,
+        }
+    }
+
+    pub fn stderr(pred: Output) -> Self {
+        Self {
+            kind: OutputKind::StdErr,
+            pred: pred,
+        }
+    }
+
+    pub(crate) fn verify_str(&self, got: &str) -> Result<()> {
+        let kind = self.kind;
+        self.pred
+            .verify_str(got)
+            .chain_err(|| ErrorKind::OutputMismatch(kind))
+    }
+
+    pub(crate) fn verify_output(&self, got: &process::Output) -> Result<()> {
+        let got = String::from_utf8_lossy(self.kind.select(got));
+        self.verify_str(&got)
     }
 }
 
@@ -102,6 +238,13 @@ mod errors {
             OutputMatches(got: String) {
                 description("Output was not as expected")
                 display("expected to not match\noutput=```{}```", got)
+            }
+            OutputMismatch(kind: super::OutputKind) {
+                description("Output was not as expected")
+                display(
+                    "Unexpected {:?}",
+                    kind
+                )
             }
         }
     }

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -4,10 +4,8 @@ extern crate assert_cli;
 fn main_binary() {
     assert_cli::Assert::main_binary()
         .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
-        .stdout()
-        .is("42")
-        .stderr()
-        .is("")
+        .stdout(assert_cli::Output::is("42"))
+        .stderr(assert_cli::Output::is(""))
         .unwrap();
 }
 
@@ -15,9 +13,7 @@ fn main_binary() {
 fn cargo_binary() {
     assert_cli::Assert::cargo_binary("assert_fixture")
         .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
-        .stdout()
-        .is("42")
-        .stderr()
-        .is("")
+        .stdout(assert_cli::Output::is("42"))
+        .stderr(assert_cli::Output::is(""))
         .unwrap();
 }


### PR DESCRIPTION
rustfmt will split long builers across lines, even when that breaks
logical grouping.

For example
```rust
assert_cli::Assert::command(&["ls", "foo-bar-foo"])
    .fails()
    .and()
    .stderr().contains("foo-bar-foo")
    .unwrap();
```
will be turned into
```rust
assert_cli::Assert::command(&["ls", "foo-bar-foo"])
    .fails()
    .and()
    .stderr()
    .contains("foo-bar-foo")
    .unwrap();
```
which obscures intent.

Normally, I don't like working around tools but this one seems
sufficient to do so.
```rust
assert_cli::Assert::command(&["ls", "foo-bar-foo"])
    .fails()
    .and()
    .stderr(assert_cli::Output::contains("foo-bar-foo"))
    .unwrap();
```

Pros
- More consistent with `with_env`
- Can add support for accepting arrays
- Still auto-complete / docs friendly
- Still expandable to additional assertions without much duplication or
  losing out on good error reporting

Cons
- More verbose if you don't `use assert_cli::{Assert, Environment, Output}`

Alternatives
- Accept distinct predicates
  - e.g. `.stderr(assert_cli::Is::text("foo-bar-foo"))`
  - e.g. `.stderr(assert_cli::Is::not("foo-bar-foo"))`
  - Strange `text` function
  - More structs to `use`
  - Less auto-complete / docs friendly (lacks contextual discovery or
    whatever the UX term is)

Fixes #70

BREAKING CHANGE: `.stdout().contains(text)` is now
`.stdout(assert_cli::Output::contains(text)`, etc.

<!--
Thank you for taking the time to contribute to this project!

To ease reviewing your changes and making sure we don't forget anything,  please
take a minute to check the following (remove lines that don't apply), and
replace this text with a description of what this PR does. Bonus points for
linking to issues! :)
-->

- [ ] I have created tests for any new feature, or added regression tests for bugfixes.
- [ ] `cargo test` succeeds
- [ ] Clippy is happy: `cargo +nightly clippy` succeeds
- [ ] Rustfmt is happy: `cargo +nightly fmt` succeeds
