### PR TITLE
Regex matching.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ difference = "1.0"
 error-chain = "0.11"
 serde_json = "1.0"
 environment = "0.1"
+regex = "0.2.5"
 
 [build-dependencies]
 skeptic = "0.13"

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -480,7 +480,7 @@ impl OutputAssertionBuilder {
         self.assertion
     }
 
-    /// Expect the command to output **exactly** this `output`.
+    /// Expect the command to match **however many times** this `output`.
     ///
     /// # Examples
     ///
@@ -494,7 +494,29 @@ impl OutputAssertionBuilder {
     /// ```
     pub fn matches(mut self, output: regex::Regex) -> Assert {
         self.assertion.expect_output.push(OutputAssertion {
-            expect: ExpectType::REGEX(output),
+            expect: ExpectType::REGEX(output, 0),
+            fuzzy: true,
+            expected_result: self.expected_result,
+            kind: self.kind,
+        });
+        self.assertion
+    }
+
+    /// Expect the command to match `nmatches` times this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    /// extern crate regex;
+    /// let re = regex::Regex::new("[0-9]{1}").unwrap();
+    /// assert_cli::Assert::command(&["echo", "42"])
+    ///     .stdout().matches_ntimes(re, 2)
+    ///     .unwrap();
+    /// ```
+    pub fn matches_ntimes(mut self, output: regex::Regex, nmatches: u32) -> Assert {
+        self.assertion.expect_output.push(OutputAssertion {
+            expect: ExpectType::REGEX(output, nmatches),
             fuzzy: false,
             expected_result: self.expected_result,
             kind: self.kind,

--- a/src/output.rs
+++ b/src/output.rs
@@ -175,10 +175,46 @@ impl fmt::Debug for FnPredicate {
 }
 
 #[derive(Debug, Clone)]
+struct RegexPredicate {
+    regex: regex::Regex,
+    times: u32,
+}
+
+impl RegexPredicate {
+    fn verify(&self, got: &[u8]) -> Result<()> {
+        let conversion = String::from_utf8_lossy(got);
+        let got = conversion.as_ref();
+        if self.times == 0 {
+            let result = self.regex.is_match(got);
+            if !result {
+                bail!(ErrorKind::OutputDoesntMatchRegexExactTimes(
+                        String::from(self.regex.as_str()),
+                        got.into(),
+                        1,
+                        1
+                    ));
+            }
+        } else {
+            let regex_matches = self.regex.captures_iter(got).count();
+            if regex_matches != (self.times as usize) {
+                bail!(ErrorKind::OutputDoesntMatchRegexExactTimes(
+                        String::from(self.regex.as_str()),
+                        got.into(),
+                        self.times,
+                        regex_matches,
+                    ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
 enum ContentPredicate {
     Is(IsPredicate),
     Contains(ContainsPredicate),
     Fn(FnPredicate),
+    Regex(RegexPredicate),
 }
 
 impl ContentPredicate {
@@ -187,6 +223,7 @@ impl ContentPredicate {
             ContentPredicate::Is(ref pred) => pred.verify(got),
             ContentPredicate::Contains(ref pred) => pred.verify(got),
             ContentPredicate::Fn(ref pred) => pred.verify(got),
+            ContentPredicate::Regex(ref pred) => pred.verify(got),
         }
     }
 }
@@ -236,6 +273,46 @@ impl Output {
             expected_result: true,
         };
         Self::new(ContentPredicate::Is(pred))
+    }
+
+    /// Expect the command to **match** this `output`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout().matches("[0-9]{2}")
+    ///     .unwrap();
+    /// ```
+    pub fn matches(output: String) -> Self {
+        let pred = RegexPredicate {
+            regex: regex::Regex::new(&output).unwrap(),
+            times: 0,
+        };
+        Self::new(ContentPredicate::Regex(pred))
+    }
+
+    /// Expect the command to **match** this `output` exacly `nmatches` times.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// extern crate assert_cli;
+    ///
+    /// assert_cli::Assert::command(&["echo"])
+    ///     .with_args(&["42"])
+    ///     .stdout().matches_ntimes("[0-9]{1}", 2)
+    ///     .unwrap();
+    /// ```
+    pub fn matches_ntimes(output: String, nmatches: u32) -> Self {
+        let pred = RegexPredicate {
+            regex: regex::Regex::new(&output).unwrap(),
+            times: nmatches,
+        };
+        Self::new(ContentPredicate::Regex(pred))
     }
 
     /// Expect the command's output to not **contain** `output`.
@@ -385,6 +462,16 @@ mod errors {
             PredicateFailed(got: String, msg: String) {
                 description("Output predicate failed")
                 display("{}\noutput=```{}```", msg, got)
+            }
+/* Adding a single error more makes this break, using the bottom one temporarily
+            OutputDoesntMatchRegex(regex: String, got: String) {
+                description("Expected to regex to match")
+                display("expected {}\n to match output=```{}```", regex, got)
+            }
+*/
+            OutputDoesntMatchRegexExactTimes(regex: String, got: String, expected_times: u32, got_times: usize) {
+                description("Expected to regex to match exact number of times")
+                display("expected {}\n to match output=```{}``` {} times instead of {} times", regex, got, expected_times, got_times)
             }
             OutputMismatch(kind: super::OutputKind) {
                 description("Output was not as expected")

--- a/src/output.rs
+++ b/src/output.rs
@@ -35,14 +35,12 @@ impl OutputAssertion {
                     }
                 }
             }
-            ExpectType::REGEX(ref self_regex, nmatches) => {
-                let regex_matches = self_regex.captures_iter(got).count();
-                if regex_matches != (nmatches as usize) {
-                    bail!(ErrorKind::OutputDoesntMatchRegexExactTimes(
+            ExpectType::REGEX(ref self_regex, _) => {
+                let result = self_regex.is_match(got);
+                if result != self.expected_result {
+                    bail!(ErrorKind::OutputDoesntMatchRegex(
                         String::from(self_regex.as_str()),
                         got.into(),
-                        nmatches,
-                        regex_matches,
                     ));
                 }
             }
@@ -69,12 +67,14 @@ impl OutputAssertion {
                     }
                 }
             }
-            ExpectType::REGEX(ref self_regex, _) => {
-                let result = self_regex.is_match(got);
-                if result != self.expected_result {
-                    bail!(ErrorKind::OutputDoesntMatchRegex(
+            ExpectType::REGEX(ref self_regex, nmatches) => {
+                let regex_matches = self_regex.captures_iter(got).count();
+                if regex_matches != (nmatches as usize) {
+                    bail!(ErrorKind::OutputDoesntMatchRegexExactTimes(
                         String::from(self_regex.as_str()),
                         got.into(),
+                        nmatches,
+                        regex_matches,
                     ));
                 }
             }

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -34,3 +34,15 @@ fn matches_with_regex() {
         .is("")
         .unwrap();
 }
+
+#[test]
+fn matches_with_regex_ntimes() {
+    let re = regex::Regex::new("[0-9]{1}").unwrap();
+    assert_cli::Assert::main_binary()
+        .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
+        .stdout()
+        .matches_ntimes(re, 2)
+        .stderr()
+        .is("")
+        .unwrap();
+}

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -1,4 +1,5 @@
 extern crate assert_cli;
+extern crate regex;
 
 #[test]
 fn main_binary() {
@@ -17,6 +18,18 @@ fn cargo_binary() {
         .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
         .stdout()
         .is("42")
+        .stderr()
+        .is("")
+        .unwrap();
+}
+
+#[test]
+fn matches_with_regex() {
+    let re = regex::Regex::new("[0-9]{2}").unwrap();
+    assert_cli::Assert::main_binary()
+        .with_env(assert_cli::Environment::inherit().insert("stdout", "42"))
+        .stdout()
+        .matches(re)
         .stderr()
         .is("")
         .unwrap();


### PR DESCRIPTION
Looking for feedback on this PR, Fixes https://github.com/killercup/assert_cli/issues/81
Added functionality to test against regex::Regex.
- match regex fuzzy must match the regex at least once to pass.
- match regex non fuzzy takes a second param to specify the number of matches it needs to find.

Also leaves room to implement predicate matching.

Added two new functions to the API
- `pub fn matches(mut self, output: regex::Regex) -> Assert`
- `pub fn matches_ntimes(mut self, output: regex::Regex, nmatches: u32) -> Assert`

You can see an example of the API in use in my own crate's branch: https://github.com/Mike-Neto/img_diff/tree/assert-cli-regex


Test's are not verified as i'm on Windows and 7 test's are failing from master (only those 7 keep failing).
Clippy and Rustfmt are not run yet as I'm just looking for feedback on the implementation itself.

- [x] I have created tests for any new feature, or added regression tests for bugfixes.
- [ ] `cargo test` succeeds
- [ ] Clippy is happy: `cargo +nightly clippy` succeeds
- [ ] Rustfmt is happy: `cargo +nightly fmt` succeeds
