### PR TITLE
Migrate to failure 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ name = "assert_fixture"
 [dependencies]
 colored = "1.5"
 difference = "2.0"
-error-chain = "0.11"
+failure = "0.1"
+failure_derive = "0.1"
 serde_json = "1.0"
 environment = "0.1"
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,7 +1,7 @@
-extern crate colored;
-use self::colored::Colorize;
-use difference::{Changeset, Difference};
 use std::fmt::{Error as fmtError, Write};
+
+use colored::Colorize;
+use difference::{Changeset, Difference};
 
 pub fn render(&Changeset { ref diffs, .. }: &Changeset) -> Result<String, fmtError> {
     let mut t = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@
 extern crate colored;
 extern crate difference;
 extern crate environment;
+#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,10 +117,12 @@
 
 #![deny(missing_docs)]
 
+extern crate colored;
 extern crate difference;
 extern crate environment;
+extern crate failure;
 #[macro_use]
-extern crate error_chain;
+extern crate failure_derive;
 extern crate serde_json;
 
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ extern crate failure_derive;
 extern crate serde_json;
 
 mod errors;
+pub use errors::AssertionError;
 
 #[macro_use]
 mod macros;

--- a/src/output.rs
+++ b/src/output.rs
@@ -338,8 +338,8 @@ impl OutputPredicate {
 
     pub(crate) fn verify(&self, got: &process::Output) -> Result<(), OutputError> {
         let got = self.kind.select(got);
-        let result = self.pred.verify(got).chain(OutputError::new(self.kind))?;
-        Ok(result)
+        self.pred.verify(got).chain(OutputError::new(self.kind))?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
In doing so, this caught a couple places we weren't providing additional
context to an error.

This does not address the errors returned by the internal string predicates.  Those are generic `failure::Error`.

Example:
```
Assertion failed for 'wc README.md'
with: Unexpected return status: failure
stdout=''''''
stderr='''wc: README.md: No such file or directory
'''
```

BREAKING CHANGE: The error type has changed from error-chain to
`assert_cli::AssertionError`.