### PR TITLE
Replace skeptic by docmatic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "http://docs.rs/assert_cli/"
 readme = "README.md"
 categories = ["development-tools::testing"]
 keywords = ["cli", "testing", "assert", "command-line-interface"]
-build = "build.rs"
 
 [[bin]]
 name = "assert_fixture"
@@ -23,11 +22,8 @@ failure_derive = "0.1"
 serde_json = "1.0"
 environment = "0.1"
 
-[build-dependencies]
-skeptic = "0.13"
-
 [dev-dependencies]
-skeptic = "0.13"
+docmatic = "0.1"
 
 [badges]
 travis-ci = { repository = "assert-rs/assert_cli" }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,0 @@
-extern crate skeptic;
-
-fn main() {
-    skeptic::generate_doc_tests(&["README.md"]);
-}

--- a/tests/docmatic.rs
+++ b/tests/docmatic.rs
@@ -1,0 +1,6 @@
+extern crate docmatic;
+
+#[test]
+fn test_readme() {
+    docmatic::assert_file("README.md");
+}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
This removes quite a few dependencies from assert_cli.

```
Removing bitflags v0.9.1
Removing bitflags v1.0.3
Removing bytecount v0.2.0
Removing cargo_metadata v0.3.3
  Adding docmatic v0.1.2
Removing error-chain v0.11.0
Removing fuchsia-zircon v0.3.3
Removing fuchsia-zircon-sys v0.3.3
Removing glob v0.2.11
Removing kernel32-sys v0.2.2
Removing proc-macro2 v0.3.8
Removing pulldown-cmark v0.1.2
Removing quote v0.5.2
Removing rand v0.4.2
Removing remove_dir_all v0.5.1
Removing same-file v0.1.3
Removing semver v0.8.0
Removing semver-parser v0.7.0
Removing serde_derive v1.0.51
Removing skeptic v0.13.2
Removing syn v0.13.7
Removing tempdir v0.3.7
Removing unicode-xid v0.1.0
Removing walkdir v1.0.7
  Adding which v2.0.0
Removing winapi v0.2.8
Removing winapi-build v0.1.1
```

<!--
Thank you for taking the time to contribute to this project!

To ease reviewing your changes and making sure we don't forget anything,  please
take a minute to check the following (remove lines that don't apply), and
replace this text with a description of what this PR does. Bonus points for
linking to issues! :)
-->

- [ ] I have created tests for any new feature, or added regression tests for bugfixes.
- [x] `cargo test` succeeds
- [ ] Clippy is happy: `cargo +nightly clippy` succeeds
- [ ] Rustfmt is happy: `cargo +nightly fmt` succeeds
