### PR TITLE
Add `example` constructor for Assert

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -80,6 +80,27 @@ impl Assert {
         }
     }
 
+    /// Run a specific example of the current crate.
+    ///
+    /// Defaults to asserting _successful_ execution.
+    pub fn example<S: AsRef<OsStr>>(name: S) -> Self {
+        Assert {
+            cmd: vec![
+                OsStr::new("cargo"),
+                OsStr::new("run"),
+                #[cfg(not(debug_assertions))]
+                OsStr::new("--release"),
+                OsStr::new("--quiet"),
+                OsStr::new("--example"),
+                name.as_ref(),
+                OsStr::new("--"),
+            ].into_iter()
+                .map(OsString::from)
+                .collect(),
+            ..Self::default()
+        }
+    }
+
     /// Run a custom command.
     ///
     /// Defaults to asserting _successful_ execution.


### PR DESCRIPTION
I have created a separate PR for this change as requested in #107.

- [ ] I have created tests for any new feature, or added regression tests for bugfixes.
- [x] `cargo test` succeeds
- [x] Clippy is happy: `cargo +nightly clippy` succeeds
- [x] Rustfmt is happy: `cargo +nightly fmt` succeeds
